### PR TITLE
fix: if a page is not found then use the 404 metadata as the default

### DIFF
--- a/app/(Site)/[[...slug]]/page.tsx
+++ b/app/(Site)/[[...slug]]/page.tsx
@@ -13,6 +13,11 @@ const parseSlug = (slug?: Array<string>) => slug?.join('/') ?? landingSlug;
 
 export async function generateMetadata({ params }: { params: { slug: Array<string> } }) {
   const { settings, page } = await getDocumentData(CMSDocument.Page, parseSlug(params.slug));
+
+  if (!page || !page.title || page.title === '') {
+    return metadata({ title: 'Page not found' }, settings);
+  }
+
   return metadata(page, settings);
 }
 

--- a/app/(Site)/not-found.tsx
+++ b/app/(Site)/not-found.tsx
@@ -4,8 +4,6 @@ import clsx from 'clsx';
 export default async function NotFound() {
   return (
     <div className="flex flex-col justify-center items-center w-full h-screen align-middle p-32">
-      {/* https://github.com/vercel/next.js/issues/45620 */}
-      <title>Page not found - Session Token</title>
       <div
         className={clsx(
           'flex flex-col gap-10 justify-center items-center align-middle',


### PR DESCRIPTION
this fixes link previews since the 404 is ssr first and only hydrated the title later previously